### PR TITLE
feat: support containerd 2.x with v3 config format

### DIFF
--- a/pkg/component/utils/registry.go
+++ b/pkg/component/utils/registry.go
@@ -31,9 +31,10 @@ import (
 )
 
 const (
-	containerdDefaultConfig = "/etc/containerd/config.toml"
-	dockerDefaultConfig     = "/etc/docker/daemon.json"
+	dockerDefaultConfig = "/etc/docker/daemon.json"
 )
+
+var containerdDefaultConfig = "/etc/containerd/config.toml"
 
 func AddOrRemoveInsecureRegistryToCRI(ctx context.Context, criType, registry string, add, dryRun bool) error {
 	switch criType {
@@ -59,8 +60,14 @@ func addOrRemoveContainerdInsecureRegistry(ctx context.Context, registry string,
 	if err != nil {
 		return
 	}
+	pluginPrefix := "io.containerd.grpc.v1.cri"
+	if v := conf.Get("version"); v != nil {
+		if n, ok := v.(int64); ok && int(n) >= 3 {
+			pluginPrefix = "io.containerd.cri.v1.images"
+		}
+	}
 	var logMsg string
-	insecureRegistries := conf.GetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "registry"}).(*toml.Tree)
+	insecureRegistries := conf.GetPath([]string{"plugins", pluginPrefix, "registry"}).(*toml.Tree)
 	if add {
 		// add registry table
 		// if the key already exists, it will not be added again.

--- a/pkg/component/utils/registry_test.go
+++ b/pkg/component/utils/registry_test.go
@@ -20,7 +20,13 @@ package utils
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/pelletier/go-toml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAddOrRemoveInsecureRegistryToCRI(t *testing.T) {
@@ -96,3 +102,69 @@ func TestAddOrRemoveInsecureRegistryToCRI(t *testing.T) {
 		})
 	}
 }
+
+func TestAddOrRemoveContainerdInsecureRegistry_V3Config(t *testing.T) {
+	v3Config := `version = 3
+root = "/var/lib/containerd"
+
+[plugins]
+  [plugins."io.containerd.cri.v1.images"]
+    [plugins."io.containerd.cri.v1.images".registry]
+      config_path = "/etc/containerd/certs.d"
+
+      [plugins."io.containerd.cri.v1.images".registry.mirrors]
+
+  [plugins."io.containerd.cri.v1.runtime"]
+`
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	require.NoError(t, os.WriteFile(configPath, []byte(v3Config), 0644))
+
+	origDefault := containerdDefaultConfig
+	containerdDefaultConfig = configPath
+	defer func() { containerdDefaultConfig = origDefault }()
+
+	// Error from systemctl restart is expected in test environment; file is written before that.
+	_ = addOrRemoveContainerdInsecureRegistry(context.Background(), "myregistry.io:5000", true, false)
+
+	result, err := toml.LoadFile(configPath)
+	require.NoError(t, err)
+
+	endpoint := result.GetPath([]string{"plugins", "io.containerd.cri.v1.images", "registry", "mirrors", "myregistry.io:5000", "endpoint"})
+	require.NotNil(t, endpoint, "insecure registry should be added under cri.v1.images path for v3 config")
+	endpointArr, ok := endpoint.([]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "http://myregistry.io:5000", endpointArr[0])
+}
+
+func TestAddOrRemoveContainerdInsecureRegistry_V2Config(t *testing.T) {
+	v2Config := `version = 2
+root = "/var/lib/containerd"
+
+[plugins]
+  [plugins."io.containerd.grpc.v1.cri"]
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      config_path = "/etc/containerd/certs.d"
+
+      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+`
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	require.NoError(t, os.WriteFile(configPath, []byte(v2Config), 0644))
+
+	origDefault := containerdDefaultConfig
+	containerdDefaultConfig = configPath
+	defer func() { containerdDefaultConfig = origDefault }()
+
+	// Error from systemctl restart is expected in test environment; file is written before that.
+	_ = addOrRemoveContainerdInsecureRegistry(context.Background(), "myregistry.io:5000", true, false)
+
+	result, err := toml.LoadFile(configPath)
+	require.NoError(t, err)
+
+	endpoint := result.GetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "registry", "mirrors", "myregistry.io:5000", "endpoint"})
+	require.NotNil(t, endpoint, "insecure registry should be added under grpc.v1.cri path for v2 config")
+}
+

--- a/pkg/scheme/core/v1/cri/containerd.go
+++ b/pkg/scheme/core/v1/cri/containerd.go
@@ -242,6 +242,33 @@ func (runnable *ContainerdRunnable) matchPauseVersion(kubeVersion string) (strin
 	return k8sMatchPauseVersion[kubeVersion], registry
 }
 
+func (r *ContainerdRunnable) isContainerdV2() bool {
+	if r.Version == "" {
+		return false
+	}
+	parts := strings.SplitN(r.Version, ".", 2)
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return false
+	}
+	return major >= 2
+}
+
+func containerdConfigVersion(configPath string) int {
+	conf, err := toml.LoadFile(configPath)
+	if err != nil {
+		return 2
+	}
+	v := conf.Get("version")
+	if v == nil {
+		return 2
+	}
+	if n, ok := v.(int64); ok {
+		return int(n)
+	}
+	return 2
+}
+
 func (runnable *ContainerdRunnable) setupContainerdConfig(ctx context.Context, dryRun bool) error {
 	// local registry not filled and is in online mode, the default repo mirror proxy will be used
 	if !runnable.Offline && runnable.LocalRegistry == "" {

--- a/pkg/scheme/core/v1/cri/containerd.go
+++ b/pkg/scheme/core/v1/cri/containerd.go
@@ -442,9 +442,13 @@ func (runnable *ContainerdRunnable) disableContainerdService(ctx context.Context
 	}
 }
 
-func (runnable *ContainerdRunnable) renderTo(w io.Writer) error {
+func (r *ContainerdRunnable) renderTo(w io.Writer) error {
 	at := tmplutil.New()
-	_, err := at.RenderTo(w, configTomlTemplate, runnable)
+	if r.isContainerdV2() {
+		_, err := at.RenderTo(w, configTomlV3Template, r)
+		return err
+	}
+	_, err := at.RenderTo(w, configTomlTemplate, r)
 	return err
 }
 

--- a/pkg/scheme/core/v1/cri/containerd.go
+++ b/pkg/scheme/core/v1/cri/containerd.go
@@ -300,6 +300,12 @@ func (runnable *ContainerdRunnable) mergeRegistryAuthIntoConfig(ctx context.Cont
 		return nil
 	}
 
+	configVer := containerdConfigVersion(configPath)
+	pluginPrefix := "io.containerd.grpc.v1.cri"
+	if configVer >= 3 {
+		pluginPrefix = "io.containerd.cri.v1.images"
+	}
+
 	// Load existing config.toml
 	conf, err := toml.LoadFile(configPath)
 	if err != nil {
@@ -311,14 +317,14 @@ func (runnable *ContainerdRunnable) mergeRegistryAuthIntoConfig(ctx context.Cont
 		return fmt.Errorf("failed to load containerd config: %w", err)
 	}
 
-	// Ensure plugins."io.containerd.grpc.v1.cri".registry.configs path exists
-	registryPath := []string{"plugins", "io.containerd.grpc.v1.cri", "registry"}
+	// Ensure plugins.<pluginPrefix>.registry.configs path exists
+	registryPath := []string{"plugins", pluginPrefix, "registry"}
 	if conf.GetPath(registryPath) == nil {
 		configsTree, treeErr := toml.TreeFromMap(map[string]interface{}{})
 		if treeErr != nil {
 			return fmt.Errorf("failed to create configs tree: %w", treeErr)
 		}
-		conf.SetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "registry", "configs"}, configsTree)
+		conf.SetPath([]string{"plugins", pluginPrefix, "registry", "configs"}, configsTree)
 	}
 
 	registryTree := conf.GetPath(registryPath)
@@ -353,7 +359,7 @@ func (runnable *ContainerdRunnable) mergeRegistryAuthIntoConfig(ctx context.Cont
 	// go-toml's Get treats dots in key names as path separators.
 	for _, host := range configsTree.Keys() {
 		if _, want := authHosts[host]; !want {
-			hostTree, ok := conf.GetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "registry", "configs", host}).(*toml.Tree)
+			hostTree, ok := conf.GetPath([]string{"plugins", pluginPrefix, "registry", "configs", host}).(*toml.Tree)
 			if !ok {
 				continue
 			}
@@ -381,7 +387,7 @@ func (runnable *ContainerdRunnable) mergeRegistryAuthIntoConfig(ctx context.Cont
 		if treeErr != nil {
 			return fmt.Errorf("failed to create auth tree for %s: %w", reg.Host, treeErr)
 		}
-		conf.SetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "registry", "configs", reg.Host, "auth"}, authTree)
+		conf.SetPath([]string{"plugins", pluginPrefix, "registry", "configs", reg.Host, "auth"}, authTree)
 		logger.Infof("updated registry auth config for %s", reg.Host)
 	}
 

--- a/pkg/scheme/core/v1/cri/containerd_test.go
+++ b/pkg/scheme/core/v1/cri/containerd_test.go
@@ -520,6 +520,62 @@ func TestMergeRegistryAuthIntoConfig_RemoveStaleAuth(t *testing.T) {
 	assert.Equal(t, "nvidia", result.GetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "containerd", "default_runtime_name"}))
 }
 
+func TestIsContainerdV2(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    bool
+	}{
+		{"v1 minor", "1.7.29", false},
+		{"v2 minor", "2.0.0", true},
+		{"v2.2", "2.2.4", true},
+		{"v3", "3.0.0", true},
+		{"v0", "0.9.0", false},
+		{"empty", "", false},
+		{"no patch", "2.0", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &ContainerdRunnable{Base: Base{Version: tt.version}}
+			assert.Equal(t, tt.want, r.isContainerdV2())
+		})
+	}
+}
+
+func TestContainerdConfigVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    int
+	}{
+		{
+			"v2 config",
+			`version = 2
+root = "/var/lib/containerd"`,
+			2,
+		},
+		{
+			"v3 config",
+			`version = 3
+root = "/var/lib/containerd"`,
+			3,
+		},
+		{
+			"no version field defaults to 2",
+			`root = "/var/lib/containerd"`,
+			2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			p := filepath.Join(dir, "config.toml")
+			require.NoError(t, os.WriteFile(p, []byte(tt.content), 0644))
+			assert.Equal(t, tt.want, containerdConfigVersion(p))
+		})
+	}
+}
+
 func TestMergeRegistryAuthIntoConfig_DryRun(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config.toml")

--- a/pkg/scheme/core/v1/cri/containerd_test.go
+++ b/pkg/scheme/core/v1/cri/containerd_test.go
@@ -682,6 +682,77 @@ func TestContainerdRunnable_renderTo_V2_BackwardCompat(t *testing.T) {
 	assert.NotNil(t, conf.GetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "sandbox_image"}))
 }
 
+func TestMergeRegistryAuthIntoConfig_V3(t *testing.T) {
+	v3Config := `version = 3
+root = "/var/lib/containerd"
+
+[plugins]
+  [plugins."io.containerd.cri.v1.images"]
+    [plugins."io.containerd.cri.v1.images".pinned_images]
+      sandbox = "registry.k8s.io/pause:3.9"
+
+    [plugins."io.containerd.cri.v1.images".containerd]
+      snapshotter = "overlayfs"
+
+    [plugins."io.containerd.cri.v1.images".registry]
+      config_path = "/etc/containerd/certs.d"
+
+      [plugins."io.containerd.cri.v1.images".registry.configs]
+
+      [plugins."io.containerd.cri.v1.images".registry.mirrors]
+
+  [plugins."io.containerd.cri.v1.runtime"]
+    [plugins."io.containerd.cri.v1.runtime".containerd]
+      default_runtime_name = "nvidia"
+
+      [plugins."io.containerd.cri.v1.runtime".containerd.runtimes]
+
+        [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.nvidia]
+          runtime_type = "io.containerd.runc.v2"
+
+          [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.nvidia.options]
+            BinaryName = "/usr/bin/nvidia-container-runtime"
+            SystemdCgroup = true
+`
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	require.NoError(t, os.WriteFile(configPath, []byte(v3Config), 0644))
+
+	runnable := &ContainerdRunnable{
+		Base: Base{
+			RegistryWithAuth: []v1.RegistrySpec{
+				{
+					Host: "registry.example.com",
+					RegistryAuth: &v1.RegistryAuth{
+						Username: "admin",
+						Password: "s3cret",
+					},
+				},
+			},
+		},
+	}
+
+	err := runnable.mergeRegistryAuthIntoConfig(context.Background(), configPath, false)
+	require.NoError(t, err)
+
+	result, err := toml.LoadFile(configPath)
+	require.NoError(t, err)
+
+	// auth under cri.v1.images path
+	authPath := []string{"plugins", "io.containerd.cri.v1.images", "registry", "configs", "registry.example.com", "auth"}
+	authTree := result.GetPath(authPath)
+	require.NotNil(t, authTree, "auth should be written to cri.v1.images path for v3 config")
+	authToml, ok := authTree.(*toml.Tree)
+	require.True(t, ok)
+	assert.Equal(t, "admin", authToml.Get("username"))
+	assert.Equal(t, "s3cret", authToml.Get("password"))
+
+	// nvidia runtime preserved
+	binName := result.GetPath([]string{"plugins", "io.containerd.cri.v1.runtime", "containerd", "runtimes", "nvidia", "options", "BinaryName"})
+	assert.Equal(t, "/usr/bin/nvidia-container-runtime", binName)
+}
+
 func TestMergeRegistryAuthIntoConfig_DryRun(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config.toml")

--- a/pkg/scheme/core/v1/cri/containerd_test.go
+++ b/pkg/scheme/core/v1/cri/containerd_test.go
@@ -576,6 +576,112 @@ root = "/var/lib/containerd"`,
 	}
 }
 
+func TestContainerdRunnable_renderTo_V3(t *testing.T) {
+	runnable := &ContainerdRunnable{
+		Base: Base{
+			Version:     "2.2.4",
+			Offline:     true,
+			DataRootDir: "/var/lib/containerd",
+			Registies: []v1.RegistrySpec{
+				{
+					Scheme: "http",
+					Host:   "127.0.0.1:5000",
+				},
+			},
+			RegistryWithAuth: []v1.RegistrySpec{
+				{
+					Host: "127.0.0.1:6000",
+					RegistryAuth: &v1.RegistryAuth{
+						Username: "myuser",
+						Password: "mypassword",
+					},
+				},
+			},
+		},
+		LocalRegistry:       "127.0.0.1:5000",
+		KubeVersion:         "1.29.0",
+		PauseVersion:        "3.9",
+		PauseRegistry:       "registry.k8s.io",
+		RegistryConfigDir:   "/etc/containerd/certs.d",
+		EnableSystemdCgroup: "true",
+	}
+
+	w := &bytes.Buffer{}
+	err := runnable.renderTo(w)
+	require.NoError(t, err)
+
+	result := w.String()
+	conf, err := toml.Load(result)
+	require.NoError(t, err)
+
+	// version = 3
+	assert.Equal(t, int64(3), conf.Get("version"))
+
+	// CRI plugin split: cri.v1.images exists
+	assert.NotNil(t, conf.GetPath([]string{"plugins", "io.containerd.cri.v1.images"}), "cri.v1.images plugin should exist")
+	assert.NotNil(t, conf.GetPath([]string{"plugins", "io.containerd.cri.v1.runtime"}), "cri.v1.runtime plugin should exist")
+	assert.NotNil(t, conf.GetPath([]string{"plugins", "io.containerd.grpc.v1.cri"}), "grpc.v1.cri plugin should exist")
+
+	// pinned_images.sandbox instead of sandbox_image
+	sandbox := conf.GetPath([]string{"plugins", "io.containerd.cri.v1.images", "pinned_images", "sandbox"})
+	assert.Equal(t, "127.0.0.1:5000/pause:3.9", sandbox)
+
+	// sandbox_image should NOT exist at old path
+	assert.Nil(t, conf.GetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "sandbox_image"}))
+
+	// registry under cri.v1.images
+	assert.Equal(t, "/etc/containerd/certs.d", conf.GetPath([]string{"plugins", "io.containerd.cri.v1.images", "registry", "config_path"}))
+
+	// auth under cri.v1.images
+	authTree := conf.GetPath([]string{"plugins", "io.containerd.cri.v1.images", "registry", "configs", "127.0.0.1:6000", "auth"})
+	require.NotNil(t, authTree, "auth should exist under cri.v1.images")
+	authToml, ok := authTree.(*toml.Tree)
+	require.True(t, ok)
+	assert.Equal(t, "myuser", authToml.Get("username"))
+	assert.Equal(t, "mypassword", authToml.Get("password"))
+
+	// SystemdCgroup under cri.v1.runtime
+	sysCgroup := conf.GetPath([]string{"plugins", "io.containerd.cri.v1.runtime", "containerd", "runtimes", "runc", "options", "SystemdCgroup"})
+	assert.Equal(t, true, sysCgroup)
+
+	// monitor renamed
+	assert.NotNil(t, conf.GetPath([]string{"plugins", "io.containerd.monitor.task.v1.cgroups"}), "monitor.task.v1.cgroups should exist")
+	assert.Nil(t, conf.GetPath([]string{"plugins", "io.containerd.monitor.v1.cgroups"}), "old monitor path should not exist")
+
+	// deprecated fields removed
+	assert.Nil(t, conf.GetPath([]string{"plugins", "io.containerd.runtime.v1.linux"}), "runtime.v1.linux should be removed")
+	assert.Nil(t, conf.GetPath([]string{"plugins", "io.containerd.snapshotter.v1.aufs"}), "aufs snapshotter should be removed")
+}
+
+func TestContainerdRunnable_renderTo_V2_BackwardCompat(t *testing.T) {
+	runnable := &ContainerdRunnable{
+		Base: Base{
+			Version:     "1.7.29",
+			Offline:     true,
+			DataRootDir: "/var/lib/containerd",
+		},
+		PauseVersion:        "3.9",
+		PauseRegistry:       "registry.k8s.io",
+		RegistryConfigDir:   "/etc/containerd/certs.d",
+		EnableSystemdCgroup: "true",
+	}
+
+	w := &bytes.Buffer{}
+	err := runnable.renderTo(w)
+	require.NoError(t, err)
+
+	conf, err := toml.Load(w.String())
+	require.NoError(t, err)
+
+	// version = 2
+	assert.Equal(t, int64(2), conf.Get("version"))
+
+	// monolithic CRI plugin
+	assert.NotNil(t, conf.GetPath([]string{"plugins", "io.containerd.grpc.v1.cri"}))
+	// sandbox_image at old path
+	assert.NotNil(t, conf.GetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "sandbox_image"}))
+}
+
 func TestMergeRegistryAuthIntoConfig_DryRun(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config.toml")

--- a/pkg/scheme/core/v1/cri/template.go
+++ b/pkg/scheme/core/v1/cri/template.go
@@ -314,3 +314,209 @@ version = 2
   address = ""
   gid = 0
   uid = 0`
+
+const configTomlV3Template = `disabled_plugins = []
+imports = []
+oom_score = 0
+plugin_dir = ""
+required_plugins = []
+{{- if .DataRootDir}}
+root = "{{.DataRootDir}}"
+{{- else}}
+root = "/var/lib/containerd"
+{{- end}}
+state = "/run/containerd"
+temp = ""
+version = 3
+
+[cgroup]
+  path = ""
+
+[debug]
+  address = ""
+  format = ""
+  gid = 0
+  level = ""
+  uid = 0
+
+[grpc]
+  address = "/run/containerd/containerd.sock"
+  gid = 0
+  max_recv_message_size = 16777216
+  max_send_message_size = 16777216
+  tcp_address = ""
+  tcp_tls_ca = ""
+  tcp_tls_cert = ""
+  tcp_tls_key = ""
+  uid = 0
+
+[metrics]
+  address = ""
+  grpc_histogram = false
+
+[plugins]
+
+  [plugins."io.containerd.gc.v1.scheduler"]
+    deletion_threshold = 0
+    mutation_threshold = 100
+    pause_threshold = 0.02
+    schedule_delay = "0s"
+    startup_delay = "100ms"
+
+  [plugins."io.containerd.cri.v1.images"]
+    disable_snapshot_annotations = true
+    discard_unpacked_layers = false
+    snapshotter = "overlayfs"
+{{- if .LocalRegistry }}
+    [plugins."io.containerd.cri.v1.images".pinned_images]
+      sandbox = "{{.LocalRegistry}}/pause:{{$.PauseVersion}}"
+{{- else}}
+    [plugins."io.containerd.cri.v1.images".pinned_images]
+      sandbox = "{{.PauseRegistry}}/pause:{{$.PauseVersion}}"
+{{- end}}
+    [plugins."io.containerd.cri.v1.images".registry]
+      config_path = "{{.RegistryConfigDir}}"
+
+      [plugins."io.containerd.cri.v1.images".registry.auths]
+
+      [plugins."io.containerd.cri.v1.images".registry.configs]
+        {{- if .RegistryWithAuth }}
+          {{- range $reg := .RegistryWithAuth }}
+            {{- if $reg.Host }}
+        [plugins."io.containerd.cri.v1.images".registry.configs."{{ $reg.Host }}"]
+              {{- if $reg.RegistryAuth }}
+          [plugins."io.containerd.cri.v1.images".registry.configs."{{ $reg.Host }}".auth]
+            username = "{{ $reg.RegistryAuth.Username }}"
+            password = "{{ $reg.RegistryAuth.Password }}"
+            auth = ""
+            identitytoken = ""
+              {{- end }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
+
+      [plugins."io.containerd.cri.v1.images".registry.headers]
+
+      [plugins."io.containerd.cri.v1.images".registry.mirrors]
+
+  [plugins."io.containerd.cri.v1.runtime"]
+    device_ownership_from_security_context = false
+    enable_selinux = false
+    tolerate_missing_hugetlb_controller = true
+    unset_seccomp_profile = ""
+
+    [plugins."io.containerd.cri.v1.runtime".cni]
+      bin_dir = "/opt/cni/bin"
+      conf_dir = "/etc/cni/net.d"
+      conf_template = ""
+      ip_pref = ""
+      max_conf_num = 1
+
+    [plugins."io.containerd.cri.v1.runtime".containerd]
+      default_runtime_name = "runc"
+      ignore_rdt_not_enabled_errors = false
+
+      [plugins."io.containerd.cri.v1.runtime".containerd.runtimes]
+
+        [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runc]
+          runtime_type = "io.containerd.runc.v2"
+
+          [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runc.options]
+            BinaryName = ""
+            IoGid = 0
+            IoUid = 0
+            NoNewKeyring = false
+            NoPivotRoot = false
+            Root = ""
+            ShimCgroup = ""
+            SystemdCgroup = {{.EnableSystemdCgroup}}
+
+  [plugins."io.containerd.grpc.v1.cri"]
+    disable_tcp_service = true
+    enable_tls_streaming = false
+    stream_idle_timeout = "4h0m0s"
+    stream_server_address = "127.0.0.1"
+    stream_server_port = "0"
+
+  [plugins."io.containerd.internal.v1.opt"]
+    path = "/opt/containerd"
+
+  [plugins."io.containerd.internal.v1.restart"]
+    interval = "10s"
+
+  [plugins."io.containerd.internal.v1.tracing"]
+    sampling_ratio = 1.0
+    service_name = "containerd"
+
+  [plugins."io.containerd.metadata.v1.bolt"]
+    content_sharing_policy = "shared"
+
+  [plugins."io.containerd.monitor.task.v1.cgroups"]
+    no_prometheus = false
+
+  [plugins."io.containerd.runtime.v2.task"]
+    platforms = ["linux/amd64"]
+    sched_core = false
+
+  [plugins."io.containerd.service.v1.diff-service"]
+    default = ["walking"]
+
+  [plugins."io.containerd.service.v1.tasks-service"]
+    rdt_config_file = ""
+
+  [plugins."io.containerd.snapshotter.v1.btrfs"]
+    root_path = ""
+
+  [plugins."io.containerd.snapshotter.v1.devmapper"]
+    async_remove = false
+    base_image_size = ""
+    discard_blocks = false
+    fs_options = ""
+    fs_type = ""
+    pool_name = ""
+    root_path = ""
+
+  [plugins."io.containerd.snapshotter.v1.native"]
+    root_path = ""
+
+  [plugins."io.containerd.snapshotter.v1.overlayfs"]
+    root_path = ""
+    upperdir_label = false
+
+  [plugins."io.containerd.snapshotter.v1.zfs"]
+    root_path = ""
+
+  [plugins."io.containerd.tracing.processor.v1.otlp"]
+    endpoint = ""
+    insecure = false
+    protocol = ""
+
+[proxy_plugins]
+
+[stream_processors]
+
+  [stream_processors."io.containerd.ocicrypt.decoder.v1.tar"]
+    accepts = ["application/vnd.oci.image.layer.v1.tar+encrypted"]
+    args = ["--decryption-keys-path", "/etc/containerd/ocicrypt/keys"]
+    env = ["OCICRYPT_KEYPROVIDER_CONFIG=/etc/containerd/ocicrypt/ocicrypt_keyprovider.conf"]
+    path = "ctd-decoder"
+    returns = "application/vnd.oci.image.layer.v1.tar"
+
+  [stream_processors."io.containerd.ocicrypt.decoder.v1.tar.gzip"]
+    accepts = ["application/vnd.oci.image.layer.v1.tar+gzip+encrypted"]
+    args = ["--decryption-keys-path", "/etc/containerd/ocicrypt/keys"]
+    env = ["OCICRYPT_KEYPROVIDER_CONFIG=/etc/containerd/ocicrypt/ocicrypt_keyprovider.conf"]
+    path = "ctd-decoder"
+    returns = "application/vnd.oci.image.layer.v1.tar+gzip"
+
+[timeouts]
+  "io.containerd.timeout.bolt.open" = "0s"
+  "io.containerd.timeout.shim.cleanup" = "5s"
+  "io.containerd.timeout.shim.load" = "5s"
+  "io.containerd.timeout.shim.shutdown" = "3s"
+  "io.containerd.timeout.task.state" = "2s"
+
+[ttrpc]
+  address = ""
+  gid = 0
+  uid = 0`


### PR DESCRIPTION
## Summary
- Add `configTomlV3Template` for containerd 2.x (version=3, split CRI plugins, pinned_images.sandbox)
- Add `isContainerdV2()` for install-time version detection and `containerdConfigVersion()` for modify-time detection
- Update `mergeRegistryAuthIntoConfig()` and `addOrRemoveContainerdInsecureRegistry()` to use version-aware plugin paths
- v1.x installations continue generating v2 config (backward compatible)

## Test plan
- [x] Unit tests for `isContainerdV2()` (7 cases) and `containerdConfigVersion()` (3 cases)
- [x] V3 template rendering test (version=3, CRI split, pinned_images, no deprecated fields)
- [x] V2 backward compatibility test (version=2, monolithic CRI, sandbox_image)
- [x] V3 auth merge test (auth written to `cri.v1.images` path)
- [x] V3 insecure registry test (endpoint written to `cri.v1.images` path)
- [x] All 39 tests pass, go vet clean